### PR TITLE
Add enode  to PeerInfo and fix unnecessary ancestor lookup

### DIFF
--- a/core/chain_indexer.go
+++ b/core/chain_indexer.go
@@ -205,11 +205,11 @@ func (c *ChainIndexer) eventLoop(currentHeader *types.Header, events chan ChainE
 				// Reorg to the common ancestor (might not exist in light sync mode, skip reorg then)
 				// TODO(karalabe, zsfelfoldi): This seems a bit brittle, can we detect this case explicitly?
 
-				// TODO(karalabe): This operation is expensive and might block, causing the event system to
-				// potentially also lock up. We need to do with on a different thread somehow.
-				if h := rawdb.FindCommonAncestor(c.chainDb, prevHeader, header); h != nil {
-					c.newHead(h.Number.Uint64(), true)
-				}
+				if rawdb.ReadCanonicalHash(c.chainDb, prevHeader.Number.Uint64()) != prevHash {
+ 					if h := rawdb.FindCommonAncestor(c.chainDb, prevHeader, header); h != nil {
+ 						c.newHead(h.Number.Uint64(), true)
+ 					}
+ 				}
 			}
 			c.newHead(header.Number.Uint64(), false)
 

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -417,9 +417,10 @@ func (rw *protoRW) ReadMsg() (Msg, error) {
 // peer. Sub-protocol independent fields are contained and initialized here, with
 // protocol specifics delegated to all connected sub-protocols.
 type PeerInfo struct {
-	ID      string   `json:"id"`   // Unique node identifier (also the encryption key)
-	Name    string   `json:"name"` // Name of the node, including client type, version, OS, custom data
-	Caps    []string `json:"caps"` // Sum-protocols advertised by this particular peer
+	Enode   string   `json:"enode"` // Node URL
+ 	ID      string   `json:"id"`    // Unique node identifier
+ 	Name    string   `json:"name"`  // Name of the node, including client type, version, OS, custom data
+ 	Caps    []string `json:"caps"`  // Protocols advertised by this peer
 	Network struct {
 		LocalAddress  string `json:"localAddress"`  // Local endpoint of the TCP data connection
 		RemoteAddress string `json:"remoteAddress"` // Remote endpoint of the TCP data connection
@@ -439,6 +440,7 @@ func (p *Peer) Info() *PeerInfo {
 	}
 	// Assemble the generic peer metadata
 	info := &PeerInfo{
+		Enode:     p.Node().String(),
 		ID:        p.ID().String(),
 		Name:      p.Name(),
 		Caps:      caps,


### PR DESCRIPTION
Add enode  to PeerInfo and fix unnecessary ancestor lookup